### PR TITLE
Fix Telegram song timing: DST fix + cron-job.org + suppress Dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "webrick"
+      - dependency-name: "addressable"
+      - dependency-name: "rexml"
+      - dependency-name: "google-protobuf"


### PR DESCRIPTION
## Summary

- **DST fix**: Updated cron expressions in both Telegram song workflows from PST to PDT (1-hour shift that was causing late delivery since March)
- **Permanent timing fix**: Removed `schedule:` triggers from both workflows — they now fire exclusively via `workflow_dispatch` triggered by cron-job.org (timezone `America/Los_Angeles`), eliminating both DST drift and GitHub Actions scheduling variability
- **Dependabot noise**: Added `.github/dependabot.yml` to suppress alerts for `webrick`, `addressable`, `rexml`, and `google-protobuf` — these are transitive deps pinned by `github-pages` and can't be independently updated

## Test plan

- [ ] Verify cron-job.org jobs fire at correct local times tonight (preview) and tomorrow morning (daily song)
- [ ] Confirm no duplicate sends (only one message per day)
- [ ] Confirm Dependabot failures no longer appear in Actions tab after merge

https://claude.ai/code/session_01Q1rgBrxWmrgGDDNYtStWRi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1rgBrxWmrgGDDNYtStWRi)_