### PR TITLE
Add X bot mention to Song Bot post update

### DIFF
--- a/_posts/2025-11-21-song-bot.md
+++ b/_posts/2025-11-21-song-bot.md
@@ -56,4 +56,6 @@ It's astonishing that a non-coder like moi can go from idea to fully functional 
 ## Update (May 2026)
 Six months in, two problems surfaced: the song was arriving noticeably late and at inconsistent times. Turned out there were two culprits conspiring together: 1) GitHub's automation scheduler having no awareness of local time or seasonal clock changes, and 2) GitHub's scheduler not being very punctual, its automations more like suggestions than alarms (ergo day-to-day randomness). So I swapped GitHub's internal scheduler for <a href="https://cron-job.org" target="_blank">cron-job.org</a>, a dedicated (and free) scheduling service that pings GitHub at exactly the right local time each day (even accounting for DST) and says "run the song workflow now, Bro". Delivery is now consistent to within a minute. The whole diagnosis-and-fix took ~20 minutes with Claude (Sonnet 4.6).
 
+While at it, added an X companion account—<a href="https://x.com/pb_song_bot" target="_blank">@pb_song_bot</a>—so the daily song now posts there too. Getting the X API to cooperate required a small credits deposit (the "free" tier is free like a bookie extending credit: new guys post cash first), but once unlocked, the same cron-job.org trigger fires both automations in perfect synchrony.
+
 — ᴘ. ᴍ. ʙ.


### PR DESCRIPTION
Adds two sentences to the May 2026 update section about @pb_song_bot on X and the bookie analogy for the credits deposit.

https://claude.ai/code/session_01Q1rgBrxWmrgGDDNYtStWRi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1rgBrxWmrgGDDNYtStWRi)_