### PR TITLE
Make dark mode the default with manual light mode toggle

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -42,6 +42,17 @@
 
   <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
 
+  <script>
+    // Theme switcher - apply saved theme before page renders to prevent flash
+    (function() {
+      const savedTheme = localStorage.getItem('theme');
+      // Default to dark, only apply light if explicitly saved
+      if (savedTheme === 'light') {
+        document.documentElement.setAttribute('data-theme', 'light');
+      }
+    })();
+  </script>
+
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS feed" href="{{ site.url }}/feed.xml" />
   <link rel="icon" href="/assets/favicon.ico" sizes="32x32">
   <link rel="icon" href="/assets/192.png" type="image/png" sizes="192x192">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,1 +1,6 @@
-<a class="muted small" href="/">← Home</a>
+<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+  <a class="muted small" href="/">← Home</a>
+  <button id="theme-toggle" aria-label="Toggle theme" style="background: none; border: none; cursor: pointer; font-size: 1.2em; padding: 0.5em; color: var(--text-color); opacity: 0.7; transition: opacity 0.2s;">
+    <span class="theme-icon">☀️</span>
+  </button>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,5 +3,47 @@
   {%- include head.html -%}
   <body>
     {{ content }}
+
+    <script>
+      // Theme toggle functionality
+      (function() {
+        const toggle = document.getElementById('theme-toggle');
+        if (!toggle) return;
+
+        const icon = toggle.querySelector('.theme-icon');
+
+        function updateIcon(theme) {
+          icon.textContent = theme === 'light' ? '🌙' : '☀️';
+        }
+
+        // Set initial icon based on current theme
+        const currentTheme = document.documentElement.getAttribute('data-theme');
+        updateIcon(currentTheme || 'dark');
+
+        // Handle toggle click
+        toggle.addEventListener('click', function() {
+          const currentTheme = document.documentElement.getAttribute('data-theme');
+          const newTheme = currentTheme === 'light' ? 'dark' : 'light';
+
+          if (newTheme === 'light') {
+            document.documentElement.setAttribute('data-theme', 'light');
+            localStorage.setItem('theme', 'light');
+          } else {
+            document.documentElement.removeAttribute('data-theme');
+            localStorage.removeItem('theme');
+          }
+
+          updateIcon(newTheme);
+        });
+
+        // Add hover effect
+        toggle.addEventListener('mouseenter', function() {
+          this.style.opacity = '1';
+        });
+        toggle.addEventListener('mouseleave', function() {
+          this.style.opacity = '0.7';
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/assets/main.css
+++ b/assets/main.css
@@ -1,8 +1,59 @@
-/* CSS Custom Properties for Light/Dark Mode */
+/* CSS Custom Properties - Dark Mode by Default */
 :root {
-  color-scheme: light dark;
+  color-scheme: dark light;
 
-  /* Light mode colors (default) */
+  /* Dark mode colors (default) */
+  --text-color: #c9d1d9;
+  --bg-color: #01242e;
+  --heading-color: #e6edf3;
+  --link-color: #8CC2DD;
+  --strong-color: #8CC2DD;
+  --muted-color: #8b949e;
+  --border-color: #0a3a47;
+  --border-light: #073340;
+
+  /* Code colors */
+  --code-bg: #032833;
+  --code-text: #ff7eb6;
+  --pre-bg: #032833;
+  --pre-text: #c9d1d9;
+  --pre-border: #0a3a47;
+
+  /* UI element colors */
+  --tag-bg: #073340;
+  --tag-hover-bg: #0a3a47;
+  --blockquote-bg: #032833;
+  --blockquote-border: #8CC2DD;
+  --focus-border: #8CC2DD;
+  --focus-shadow: rgba(140, 194, 221, 0.3);
+
+  /* Footnote colors */
+  --footnote-color: #8b949e;
+
+  /* Table colors */
+  --table-border: #0a3a47;
+  --table-header-bg: rgba(255, 255, 255, 0.05);
+  --table-section-header-bg: rgba(140, 194, 221, 0.15);
+  --table-current-row-bg: transparent;
+  --table-accent-border: #8CC2DD;
+
+  /* Input colors */
+  --input-bg: #011a23;
+  --input-border: #0a3a47;
+
+  /* Highlight colors */
+  --mark-yellow: rgba(200, 180, 100, 0.3);
+  --mark-turquoise: rgb(56, 139, 129);
+  --mark-lilac: rgb(137, 87, 168);
+  --mark-gray: rgb(110, 118, 129);
+  --notabene-text: #8b949e;
+}
+
+/* Light mode colors (when toggled) */
+html[data-theme="light"] {
+  color-scheme: light;
+
+  /* Light mode colors */
   --text-color: #222;
   --bg-color: #fafafa;
   --heading-color: #111;
@@ -47,56 +98,6 @@
   --mark-lilac: rgb(243, 228, 255);
   --mark-gray: rgb(211, 211, 211);
   --notabene-text: rgb(79, 79, 79);
-}
-
-/* Dark mode colors */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --text-color: #c9d1d9;
-    --bg-color: #01242e;
-    --heading-color: #e6edf3;
-    --link-color: #8CC2DD;
-    --strong-color: #8CC2DD;
-    --muted-color: #8b949e;
-    --border-color: #0a3a47;
-    --border-light: #073340;
-
-    /* Code colors */
-    --code-bg: #032833;
-    --code-text: #ff7eb6;
-    --pre-bg: #032833;
-    --pre-text: #c9d1d9;
-    --pre-border: #0a3a47;
-
-    /* UI element colors */
-    --tag-bg: #073340;
-    --tag-hover-bg: #0a3a47;
-    --blockquote-bg: #032833;
-    --blockquote-border: #8CC2DD;
-    --focus-border: #8CC2DD;
-    --focus-shadow: rgba(140, 194, 221, 0.3);
-
-    /* Footnote colors */
-    --footnote-color: #8b949e;
-
-    /* Table colors */
-    --table-border: #0a3a47;
-    --table-header-bg: rgba(255, 255, 255, 0.05);
-    --table-section-header-bg: rgba(140, 194, 221, 0.15);
-    --table-current-row-bg: transparent;
-    --table-accent-border: #8CC2DD;
-
-    /* Input colors */
-    --input-bg: #011a23;
-    --input-border: #0a3a47;
-
-    /* Highlight colors - adjusted for dark mode */
-    --mark-yellow: rgba(200, 180, 100, 0.3);
-    --mark-turquoise: rgb(56, 139, 129);
-    --mark-lilac: rgb(137, 87, 168);
-    --mark-gray: rgb(110, 118, 129);
-    --notabene-text: #8b949e;
-  }
 }
 
 body {

--- a/pages/colophon.md
+++ b/pages/colophon.md
@@ -10,33 +10,9 @@ ogimage: divider-g2fa5b2a44_1280.png
 
 This site is hosted on [GitHub Pages and built with Jekyll using Clio](/this-site), a template and theme designed by Dan Romero. And you know it's really me because it's <a href="https://keybase.io/berens" target="_blank">web2</a>- and <a href="https://nf.td/pmb" target="_blank">web3</a>-verified.
 
-<span id="color-scheme-info"></span>
-
-<script>
-(function() {
-  const isDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const infoElement = document.getElementById('color-scheme-info');
-
-  if (isDark) {
-    infoElement.innerHTML = 'You\'re viewing this site in 🌑 <strong>dark mode</strong> because your system preferences are set to dark. This site automatically inherits your system\'s color scheme preference.';
-  } else {
-    infoElement.innerHTML = 'You\'re viewing this site in the original 🔆 <strong>light mode</strong>. If you change your system preferences to dark mode, this site will automatically switch to dark mode.';
-  }
-
-  // Listen for changes in color scheme preference
-  if (window.matchMedia) {
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
-      if (e.matches) {
-        infoElement.innerHTML = 'You\'re viewing this site in 🌑 <strong>dark mode</strong> because your system preferences are set to dark. This site automatically inherits your system\'s color scheme preference.';
-      } else {
-        infoElement.innerHTML = 'You\'re viewing this site in the original 🔆 <strong>light mode</strong>. If you change your system preferences to dark mode, this site will automatically switch to dark mode.';
-      }
-    });
-  }
-})();
-</script>
-
 Sans-serif typefacing.
+
+Dark mode by default. Toggle to light mode using the sun/moon button in the header if you prefer.
 
 Imprinted (and [vibe coded](/vibe-coding)) at San Francisco, California.
 


### PR DESCRIPTION
Major refactor from system preference to dark-by-default:

CSS changes (assets/main.css):
- Swapped color schemes: dark colors now in :root (default)
- Light colors moved to html[data-theme="light"]
- Removed @media (prefers-color-scheme) queries
- Changed color-scheme to "dark light"

UI changes:
- Added sun/moon toggle button in header (nav.html)
- Button positioned next to "← Home" link
- Shows ☀️ in dark mode, 🌙 in light mode
- Subtle opacity hover effect

JavaScript (head.html + default.html):
- Early script applies saved theme to prevent flash
- Toggle handler switches between themes
- Saves preference to localStorage
- Dark mode is default (no localStorage = dark)

Colophon update:
- Removed system preference detection script
- Updated text to explain manual toggle

Users now see dark mode by default with option to toggle light.