### PR TITLE
Fix undersized photo in wine post

### DIFF
--- a/_posts/2025-07-03-wine.md
+++ b/_posts/2025-07-03-wine.md
@@ -29,7 +29,7 @@ Over a decade ago there was a winery in the Dogpatch neighborhood of San Francis
 
 Before that, at Michigan, we had the Wolverine Wine Club, which was supposed to introduce us uncouth MBAs to some refinement through good wine. But each event, no matter how elegant the venue, would devolve into utter debauchery. This so incensed the faculty advisor, who happened to be a world-renowned sommelier, that he quit indignantly. We look back on the WWC and laugh, but then, I think, that fun and enjoyment is the real meaning of *oenophilia:* the mirth of wine; not feigning the ability to detect notes of wet limestone and saddle soap.
 
-<p><img src="/assets/og/post_smell.jpg" width="20%"><span class="muted small">Me stopping you mid-sentence to detect notes of petrichor.</span></p>
+<p><img src="/assets/og/post_smell.jpg" alt="Man sniffing a glass of wine" style="width: 50%;"><span class="muted small">Me stopping you mid-sentence to detect notes of petrichor.</span></p>
 
 ## Let's reel it in
 


### PR DESCRIPTION
The inline image was set to width="20%", rendering it thumbnail-sized on both mobile and desktop. Bump it to 50% via inline style to match the sizing pattern used by other posts, and add alt text.


Claude-Session: https://claude.ai/code/session_013CHLvRctBPd1sCT71wY1Xm