### PR TITLE
Make theme toggle more subtle with muted text symbols

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
   <a class="muted small" href="/">← Home</a>
-  <button id="theme-toggle" aria-label="Toggle theme" style="background: none; border: none; cursor: pointer; font-size: 1.2em; padding: 0.5em; color: var(--text-color); opacity: 0.7; transition: opacity 0.2s;">
-    <span class="theme-icon">☀️</span>
+  <button id="theme-toggle" aria-label="Toggle theme" style="background: none; border: none; cursor: pointer; font-size: 0.9em; padding: 0.5em; color: var(--muted-color); opacity: 0.6; transition: opacity 0.2s;">
+    <span class="theme-icon">☼</span>
   </button>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
         const icon = toggle.querySelector('.theme-icon');
 
         function updateIcon(theme) {
-          icon.textContent = theme === 'light' ? '🌙' : '☀️';
+          icon.textContent = theme === 'light' ? '☾' : '☼';
         }
 
         // Set initial icon based on current theme


### PR DESCRIPTION
Replaced colorful emojis with text-based symbols:
- Dark mode (☼ sun) → click to switch to light
- Light mode (☾ moon) → click to switch to dark

Style changes:
- Use var(--muted-color) instead of var(--text-color)
- Reduced size from 1.2em to 0.9em
- Reduced opacity from 0.7 to 0.6
- Symbols can be styled with CSS (unlike emojis)

Result: Much more subtle, refined toggle that doesn't compete with content.