### PR TITLE
Adjust theme toggle size and vertical alignment

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,6 @@
 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
   <a class="muted small" href="/">← Home</a>
-  <button id="theme-toggle" aria-label="Toggle theme" style="background: none; border: none; cursor: pointer; font-size: 0.9em; padding: 0.5em; color: var(--muted-color); opacity: 0.6; transition: opacity 0.2s;">
+  <button id="theme-toggle" aria-label="Toggle theme" style="background: none; border: none; cursor: pointer; font-size: 1.1em; padding: 0; line-height: 1; color: var(--muted-color); opacity: 0.6; transition: opacity 0.2s;">
     <span class="theme-icon">☼</span>
   </button>
 </div>


### PR DESCRIPTION
Size adjustment:
- Increased from 0.9em to 1.1em (better visibility)
- Still subtle but not too small

Alignment improvements:
- Removed padding (0.5em → 0) for cleaner alignment
- Added line-height: 1 to eliminate extra vertical space
- Now properly aligns with "← Home" link baseline

Result: Toggle is more visible and vertically centered with nav text.